### PR TITLE
A minor change in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to our project! This document provid
 2. **Clone your fork**
 
    ```
-   git clone https://github.com/ChiragAgg5k/cal-buddy
+   git clone https://github.com/'your username'/cal-buddy
    cd cal-buddy
    ```
 


### PR DESCRIPTION
When a user forks a repository then the nomenclature of the name of the forked repo basically looks like this:

`'username/repo-name'`

That's why instead of using:

`git clone https://github.com/ChiragAgg5k/cal-buddy`

We can use this:

`git clone https://github.com/'your username'/cal-buddy`

It would be much easier for the users when they fork this repository, this would clear the confusion for them if they encounter any while forking.

That said, i can be wrong just wanted to make it clear for the users. At the end its up to you @ChiragAgg5k 