### PR TITLE
Typescript typing updation in calendar.tsx

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -54,8 +54,12 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: (props: React.SVGProps<SVGSVGElement>) => (
+          <ChevronLeft {...props} className="h-4 w-4" />
+        ),
+        IconRight: (props: React.SVGProps<SVGSVGElement>) => (
+          <ChevronRight {...props} className="h-4 w-4" />
+        ),
       }}
       {...props}
     />


### PR DESCRIPTION
**TypeScript Typing for `ChevronLeft` and `ChevronRight` Icons:**  In the components object for the DayPicker, the icons `ChevronLeft` and `ChevronRight` are being used without explicitly specifying props or using typing for the passed props. While it may not throw an error, you could add typings for better type safety:

```bash
IconLeft: (props: React.SVGProps<SVGSVGElement>) => <ChevronLeft {...props} className="h-4 w-4" />,
IconRight: (props: React.SVGProps<SVGSVGElement>) => <ChevronRight {...props} className="h-4 w-4" />
```