### PR TITLE
Add/contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Contributors
 A big shoutout and heartfelt thanks to all our amazing contributors for their incredible efforts and dedication! This project wouldn’t be where it is without you. 
+
 <a href="https://github.com/ChiragAgg5k/cal-buddy/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=ChiragAgg5k/cal-buddy" />
 </a>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
   - [Installation using Daytona](#installation-using-daytona)
   - [Technologies Used](#technologies-used)
   - [Contributing](#contributing)
+  - [Contributors](#contributors)
   - [License](#license)
+    
 
 ## Demo
 
@@ -93,4 +95,11 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ---
 
+## Contributors
+A big shoutout and heartfelt thanks to all our amazing contributors for their incredible efforts and dedication! This project wouldn’t be where it is without you. 
+<a href="https://github.com/ChiragAgg5k/cal-buddy/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=ChiragAgg5k/cal-buddy" />
+</a>
+
+---
 Made with ❤️ by [Chirag Aggarwal](https://github.com/ChiragAgg5k)


### PR DESCRIPTION
fixes: #44 
This PR introduces a new section called "Contributors" to acknowledge and celebrate the efforts of everyone who has contributed to this project. The contributors are dynamically showcased using an image generated by [Contrib Rocks](https://contrib.rocks/), which creates a visually appealing representation of the contributors' GitHub profiles.